### PR TITLE
Add dark & momentum-dark hammer themes

### DIFF
--- a/hammer/resource/themes/dark.kv
+++ b/hammer/resource/themes/dark.kv
@@ -1,0 +1,29 @@
+// Simple dark theme. Unused keys are retained as example material
+"theme"
+{
+	"qt"
+	{
+		"Style"					"Fusion"
+		"WindowsTitleBarColor"	"0 0 0"
+		"WindowText"  			"255 255 255"
+		"Button"  				"53 53 53"
+		"Text"  				"255 255 255"
+		"BrightText"  			"200 0 0"
+		"ButtonText"  			"255 255 255"
+		"Base"  				"25 25 25"
+		"Window"  				"40 40 40"
+		"Highlight"  			"219 65 65"
+		"HighlightedText" 		"10 10 10"
+		"AlternateBase" 		"40 40 40"
+		"ToolTipBase"  			"255 255 255"
+		"ToolTipText" 			"255 255 255"
+		//"PlaceholderText" 	""	
+		//"Light"  				""
+		//"Midlight"  			""
+		//"Dark"  				""
+		//"Mid" 				""
+		//"Link"  				""
+		//"LinkVisited" 		""
+		//"Shadow" 				""
+	}
+}

--- a/hammer/resource/themes/momentum-dark.kv
+++ b/hammer/resource/themes/momentum-dark.kv
@@ -1,0 +1,21 @@
+// Momentum mod dark theme
+"theme"
+{
+	"qt"
+	{
+		"Style"				"Fusion"
+		"WindowText"  		"255 255 255"
+		"Button"  			"79 79 79"
+		"Text"  			"255 255 255"
+		"BrightText"  		"200 0 0"
+		"ButtonText"  		"255 255 255"
+		"Base"  			"32 32 32"
+		"Window"  			"50 50 50"
+		"Highlight"  		"24 150 211"
+		"HighlightedText" 	"32 32 32"
+		"Link"  			"24 150 211"
+		"AlternateBase" 	"79 79 79"
+		"ToolTipBase"  		"255 255 255"
+		"ToolTipText" 		"255 255 255"
+	}
+}


### PR DESCRIPTION
Adds two Qt themes for Hammer. 

This should not be merged until the theme support in hammer is merged. 

Dark theme:
![image](https://user-images.githubusercontent.com/19717056/161158747-702c75ab-d4e7-4c79-95ff-85309a4125fd.png)

Momentum dark theme:
![image](https://user-images.githubusercontent.com/19717056/161158882-948144c8-82b6-4bc8-b1ff-caf950a66ff9.png)
