### PR TITLE
feat: Add BaseLight field to disable drawing sprites in buildcubemaps

### DIFF
--- a/fgd/bases/BaseLight.fgd
+++ b/fgd/bases/BaseLight.fgd
@@ -37,6 +37,8 @@
 
 	_distance(integer) : "Maximum Distance" : 0 : "The distance that light is allowed to cast."
 
+	_nocubemapsprite(boolean) : "No Sprite in Cubemap" : 1 : "If set, this light will not draw a sprite during cubemap building"
+
 	// Inputs
 	input TurnOn(void) : "Turn the light on."
 	input TurnOff(void) : "The the light off."


### PR DESCRIPTION
This adds a new field named `_nocubemapsprite` to `BaseLight`. Enabling this will prevent the light from drawing a sprite during `buildcubemaps`. 

Per JJ and Andy this is enabled by default--disabling the sprites. Compiling old VMFs might make them a little less shiny looking now. 