### PR TITLE
Seperate BaseLight into BaseLightFalloff and 2 new kvs

### DIFF
--- a/fgd/bases/BaseLight.fgd
+++ b/fgd/bases/BaseLight.fgd
@@ -1,7 +1,4 @@
-@BaseClass 
-	sphere(_fifty_percent_distance)
-	sphere(_zero_percent_distance)
-	sphere(_distance)
+@BaseClass
 	color(255 255 0)
 = BaseLight
 	[
@@ -26,17 +23,16 @@
 		9 : "Slow strobe"
 		12 : "Underwater light mutation"
 		]
+		
+	spawnflags(flags)  =
+		[
+		1: "Initially dark" : 0
+		]
 	pattern(string) : "Custom Appearance" : "" : "Set a custom pattern of light brightness for this light. Pattern format is a string of characters, where 'a' is total darkness, 'z' fully bright. i.e. 'aaggnnttzz' would be a steppy fade in from dark to light."
 	fadetickinterval(float) : "Fade Tick Interval" : 0.1 : "The tick interval of the light's fade, in seconds. Lower values cause a faster fade."
-	_constant_attn(string)	: "Constant" : "0"
-	_linear_attn(string)	: "Linear" : "0"
-	_quadratic_attn(string)	: "Quadratic" : "1"
-	_fifty_percent_distance(string) : "50 percent falloff distance" : "0": "Distance at which brightness should fall off to 50%. If set, overrides linear constant and quadratic paramaters."
-	_zero_percent_distance(string) : "0 percent falloff distance" : "0": "Distance at which brightness should fall off to negligible (1/256)%. Must set _fifty_percent_distance to use."
-	_hardfalloff(integer) : "Hard Falloff" : 0 : "If set, causes lights to fall to exactly zero beyond the zero percent distance. May cause unrealistic lightijng if not used carefully."
 
-	_distance(integer) : "Maximum Distance" : 0 : "The distance that light is allowed to cast."
-
+	_castentityshadow(boolean) : "Cast Entity Shadows" : 1 : "Objects illuminated by this light will cast a directional shadow."
+	_shadoworiginoffset(vector) : "Entity shadow offset" : "0 0 0" : "A world-space offset applied to the shadow origin, in units. X Y Z."
 	_nocubemapsprite(boolean) : "No Sprite in Cubemap" : 1 : "If set, this light will not draw a sprite during cubemap building"
 
 	// Inputs

--- a/fgd/bases/BaseLightFalloff.fgd
+++ b/fgd/bases/BaseLightFalloff.fgd
@@ -1,0 +1,14 @@
+@BaseClass
+	sphere(_fifty_percent_distance)
+	sphere(_zero_percent_distance)
+	sphere(_distance)
+= BaseLightFalloff
+	[
+	_constant_attn(string)	: "Constant" : "0"
+	_linear_attn(string)	: "Linear" : "0"
+	_quadratic_attn(string)	: "Quadratic" : "1"
+	_fifty_percent_distance(string) : "50 percent falloff distance" : "0": "Distance at which brightness should fall off to 50%. If set, overrides linear constant and quadratic parameters."
+	_zero_percent_distance(string) : "0 percent falloff distance" : "0": "Distance at which brightness should fall off to negligible (1/256)%. Must set _fifty_percent_distance to use."
+	_hardfalloff(integer) : "Hard Falloff" : 0 : "If set, causes lights to fall to exactly zero beyond the zero percent distance. May cause unrealistic lighting if not used carefully."
+	_distance(integer) : "Maximum Distance" : 0 : "The distance that light is allowed to cast."
+	]

--- a/fgd/point/light/light.fgd
+++ b/fgd/point/light/light.fgd
@@ -1,13 +1,8 @@
-@PointClass base(BaseEntityPoint, BaseLight)
+@PointClass base(BaseEntityPoint, BaseLight, BaseLightFalloff)
 	light() 
 	iconsprite("editor/light.vmt") 
-	sphere(_distance) 
 	line(255 255 255, targetname, target)
-= light: "An invisible omnidirectional lightsource."
+= light: "An invisible omnidirectional light-source."
 	[
 	_removeaftercompile(boolean) : "Remove After Compile" : 0 : "If set, removes this entity after processing the map with VRAD"
-	spawnflags(flags)  =
-		[
-		1: "Initially dark" : 0
-		]
 	]

--- a/fgd/point/light/light_directional.fgd
+++ b/fgd/point/light/light_directional.fgd
@@ -1,11 +1,8 @@
-@PointClass base(Angles)
+@PointClass base(BaseEntityPoint, BaseLight)
 	color(255 255 0)
 	iconsprite("editor/light_directional.vmt")
 = light_directional: "A directional light with no falloff. Similar to sunlight in light_environment."
 	[
 	pitch(integer) : "Pitch" : 0 : "The downward pitch of the light from the sun. 0 is horizontal, -90 is straight down."
-	_light(color255) : "Brightness" : "255 255 255 200"
-	_lighthdr(color255) : "BrightnessHDR" : "-1 -1 -1 1"
-	_lightscalehdr(float) : "BrightnessScaleHDR" : 0.7 : "Amount to scale the light by when compiling for HDR."
 	sunspreadangle(float) : "SpreadAngle" : 0 : "The angular extent of the light for casting soft shadows. Higher numbers are more diffuse. 5 is a good starting value."
 	]

--- a/fgd/point/light/light_environment.fgd
+++ b/fgd/point/light/light_environment.fgd
@@ -1,48 +1,12 @@
-@PointClass base(BaseEntityPoint, Angles) 
+@PointClass base(BaseEntityPoint, BaseLight, Angles) 
 	iconsprite("editor/ficool2/light_environment.vmt") 
 	color(255 255 0)
 	lightprop("models/editor/spot.mdl")
 = light_environment: "Sets the color and angle of the light from the sun and sky."
 	[
 	pitch(angle_negative_pitch) : "Pitch" : "0" : "The downward pitch of the light from the sun. 0 is horizontal, -90 is straight down."
-	_light(color255) : "Brightness" : "255 255 255 200"
 	_ambient(color255) : "Ambient light" : "255 255 255 20"
-	_lighthdr(color255) : "BrightnessHDR" : "-1 -1 -1 1"
-	_lightscalehdr(float) : "BrightnessScaleHDR" : 1 : "Amount to scale the light by when compiling for HDR."
 	_ambienthdr(color255) : "AmbientHDR" : "-1 -1 -1 1"
 	_ambientscalehdr(float) : "AmbientScaleHDR" : 1 : "Amount to scale the ambient light by when compiling for hdr."
 	sunspreadangle(float) : "SunSpreadAngle" : 5 : "The angular extent of the sun for casting soft shadows. Higher numbers are more diffuse. 5 is a good starting value."
-
-	style[engine](integer) : "Appearance" : 0
-	style(choices) : "Appearance" : 0 =
-		[
-		0 : "Normal"
-		10: "Fluorescent flicker"
-		2 : "Slow, strong pulse"
-		11: "Slow pulse, noblack"
-		5 : "Gentle pulse"
-		1 : "Flicker A"
-		6 : "Flicker B"
-		3 : "Candle A"
-		7 : "Candle B"
-		8 : "Candle C"
-		4 : "Fast strobe"
-		9 : "Slow strobe"
-		12 : "Underwater light mutation"
-		]
-	pattern(string) : "Custom Appearance" : "" : "Set a custom pattern of light brightness for this light. Pattern format is a string of characters, where 'a' is total darkness, 'z' fully bright. i.e. 'aaggnnttzz' would be a steppy fade in from dark to light."
-
-	_castentityshadow[engine](boolean)
-	_castentityshadow[GMod](Choices) : "Cast entity shadows" : 0 : "Objects illuminated by this light will cast a directional shadow." =
-		[
-		0 : "Don't affect entity shadow angles"
-		1 : "Affect entity shadow angles"
-		]
-
-	// Inputs
-	input TurnOn(void) : "Turn the Sun on."
-	input TurnOff(void) : "The the Sun off."
-	input Toggle(void) : "Toggle the Sun's current state."
-	input SetPattern(string) : "Set a custom pattern of light brightness for the Sun. Pattern format is a string of characters, where 'a' is total darkness, 'z' fully bright. i.e. 'aaggnnttzz' would be a steppy fade in from dark to light."
-	input FadeToPattern(string) : "Fades from first value in old pattern, to first value in the new given pattern. Pattern format is a string of characters, where 'a' is total darkness, 'z' fully bright. i.e. 'aaggnnttzz' would be a steppy fade in from dark to light."
 	]

--- a/fgd/point/light/light_spot.fgd
+++ b/fgd/point/light/light_spot.fgd
@@ -1,7 +1,6 @@
-@PointClass base(BaseEntityPoint, BaseLight)
+@PointClass base(BaseEntityPoint, BaseLight, BaseLightFalloff)
 	lightprop("models/editor/spot.mdl") 
 	lightcone() 
-	sphere(_distance) 
 	line(255 255 255, targetname, target)
 = light_spot: "An invisible and directional spotlight."
 	[
@@ -12,9 +11,4 @@
 	_exponent(integer) : "Focus" : 1
 	_removeaftercompile(boolean) : "Remove After Compile" : 0 : "If set, removes this entity after processing the map with VRAD"
 	pitch(angle_negative_pitch) : "Pitch" : -90
-	spawnflags(flags)  =
-		[
-		1: "Initially dark" : 0
-		]
-
 	]


### PR DESCRIPTION
Since the fall off kvs are in their own base now, `light_directional` and `light_environment` now have keyvalues from BaseLight. A quick check in game shows these are indeed on both of these entities, so should work!

Resolves #180 
Resolves #181 