### PR TITLE
Fix spelling of "Schrodinger" in prop_weighted_cube

### DIFF
--- a/fgd/point/prop/prop_weighted_cube.fgd
+++ b/fgd/point/prop/prop_weighted_cube.fgd
@@ -14,7 +14,7 @@
 		2: "[2] Discouragement Redirection Cube"
 		3: "[3] Edgeless Safety Cube"
 		4: "[4] Antique Storage Cube"
-		5: "[5] Schoedinger's Cube"
+		5: "[5] Schrodinger's Cube"
 		6: "[6] Custom model"
 		]
 
@@ -32,7 +32,7 @@
 		"models/props/reflection_cube.mdl": "Discouragement Redirection"
 		"models/props_gameplay/mp_ball.mdl": "Edgeless Safety"
 		"models/props_underground/underground_weighted_cube.mdl": "Antique"
-		"models/props/schrodinger_cube.mdl": "Schroedinger"
+		"models/props/schrodinger_cube.mdl": "Schrodinger"
 		]
 
 	skin(integer) : "Skin" : 0 : "The old skin property, mainly to show in Hammer. "


### PR DESCRIPTION
Now uses `Schrodinger` as that is more consistent with the rest of the codebase

~~Would change it to `Schrodinger` but the code which handles model selection uses `Schroedinger` which _is_ an accepted spelling, so I've changed all instances of it to say `Schroedinger`.~~