### PR TITLE
Workaround prop_testchamber_door looping the close animation

### DIFF
--- a/fgd/point/prop/prop_testchamber_door.fgd
+++ b/fgd/point/prop/prop_testchamber_door.fgd
@@ -18,6 +18,10 @@
 	skin(integer) : "Skin" : 0 : "Skin to use in game"
 	model(studio) : "Model" : "models/props/portal_door_combined.mdl" : "Model to use in-game"
 
+	// Temporary workaround for doors looping the close animation
+	// Remove once https://github.com/StrataSource/Engine/issues/737 is implemented
+	defaultanim(string) readonly : "<Default Animation>" : "idleclose" : "Ignore, needed to prevent the close animation from looping in Hammer"
+
 	// Inputs
 	input Open(void) : "Open the door and cause the areaportal to return to fading."
 	input Close(void) : "Close the door and cause the areaportal to close."


### PR DESCRIPTION
This adds a read-only `defaultanim` keyvalue to `prop_testchamber_door` to prevent the closing animation from being looped infinitely in Hammer. This used to be done by setting the entity to a custom Hammer model with no animations, but this is no longer possible since we now allow setting custom models.

The proper fix to this is StrataSource/Engine#737, but I don't see that being implemented for a while and the looping close animation is really distracting for me, so I implemented this temporary workaround in the meantime.