### PR TITLE
feat: Misc updates to zone timer entities

### DIFF
--- a/db/factories/momentum.txt
+++ b/db/factories/momentum.txt
@@ -382,5 +382,4 @@ zone_timer_start
 zone_timer_cancel
 zone_timer_end
 zone_timer_stage
-zone_timer_stage_end
 zone_timer_checkpoint

--- a/fgd/brush/trigger/zone_timer_cancel.fgd
+++ b/fgd/brush/trigger/zone_timer_cancel.fgd
@@ -1,6 +1,6 @@
 @SolidClass appliesto(MOMENTUM)
 = zone_timer_cancel : "Zone that cancels the timer."
 	[
-	filter_name(string) : "Filter Name" : : "filter_activator entity to use for this zone."
+	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
 	track_number(integer) : "Track Number" : 0 : "Track number that this entity belongs to. 0 = main map, 1+ = bonus (of that number)."
 	]

--- a/fgd/brush/trigger/zone_timer_cancel.fgd
+++ b/fgd/brush/trigger/zone_timer_cancel.fgd
@@ -3,4 +3,5 @@
 	[
 	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
 	track_number(integer) : "Track Number" : 0 : "Track number that this entity belongs to. 0 = main map, 1+ = bonus (of that number)."
+	stage_number(integer) : "Stage Number" : 1 : "The stage this cancel zone is part of. If this track has no stages, leave this as Stage 1."
 	]

--- a/fgd/brush/trigger/zone_timer_checkpoint.fgd
+++ b/fgd/brush/trigger/zone_timer_checkpoint.fgd
@@ -1,7 +1,7 @@
 @SolidClass appliesto(MOMENTUM)
 = zone_timer_checkpoint : "Zone used to denote progress in a linear map. zone_timer_start is automatically checkpoint (zone number) 1!" 
 	[
-	filter_name(string) : "Filter Name" : : "filter_activator entity to use for this zone."
+	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
 	track_number(integer) : "Track Number" : 0 : "Track number that this entity belongs to. 0 = main map, 1+ = bonus (of that number)."
 	stage_number(integer) : "Stage Number" : 1 : "The stage this checkpoint is part of. If this track has no stages, leave this as Stage 1."
 	checkpoint_number(integer) : "Checkpoint Number" : 2 : "The checkpoint number of this zone within its respective stage. NOTE: 1 is reserved for the stage start! 2+ are free for your checkpoint zones, so start at 2!"

--- a/fgd/brush/trigger/zone_timer_end.fgd
+++ b/fgd/brush/trigger/zone_timer_end.fgd
@@ -1,6 +1,6 @@
 @SolidClass appliesto(MOMENTUM)
 = zone_timer_end : "Zone that finishes the timer."
 	[
-	filter_name(string) : "Filter Name" : : "filter_activator entity to use for this zone."
+	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
 	track_number(integer) : "Track Number" : 0 : "Track number that this entity belongs to. 0 = main map, 1+ = bonus (of that number)."
 	]

--- a/fgd/brush/trigger/zone_timer_stage.fgd
+++ b/fgd/brush/trigger/zone_timer_stage.fgd
@@ -5,7 +5,7 @@
 	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
 	stage_number(integer) : "Stage Number" : 2 : "The stage number of this zone. NOTE: 1 is reserved for start! 2+ are free for your stage zones, so start at 2!"
 	checkpoints_required(boolean) : "Checkpoints Required" : 0 : "Is the player required to activate all checkpoints before progressing to the next stage? Otherwise, checkpoint zones may be skipped for this stage."
-	checkpoints_ordered(boolean) : "Checkpoints Ordered" : 1 : "Are the checkpoints placed in a particular order?"
+	checkpoints_ordered(boolean) : "Checkpoints Ordered" : 1 : "Do the checkpoints in this segment have a logical order, even if the player is not required to activate them all?"
 	limit_ground_speed(boolean) : "Limit ground speed" : 1 : "Limit ground speed to walking speed (prevents bunny hopping)."
 	safe_height(float) : "Safe Height" : -1 : "Height that the player must be under to start a run of this stage track. Safe height is not a factor in activating the stage when running the full main track. -1 = full zone, 0 = base of zone, > 0 = custom height."
 	restart_destination(target_destination) : "Restart Destination" : : "The entity specifying the point to which the player should be teleported when restarting a stage. The player will be placed directly on the ground below this point if possible."

--- a/fgd/brush/trigger/zone_timer_stage.fgd
+++ b/fgd/brush/trigger/zone_timer_stage.fgd
@@ -2,10 +2,11 @@
 = zone_timer_stage : "Starting zone for each stage of a map. zone_timer_start is automatically stage 1!" 
 	[
 	stage_name(string) : "Stage Name" : : "A custom name for this stage (optional)."
-	filter_name(string) : "Filter Name" : : "filter_activator entity to use for this zone."
+	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
 	stage_number(integer) : "Stage Number" : 2 : "The stage number of this zone. NOTE: 1 is reserved for start! 2+ are free for your stage zones, so start at 2!"
-	checkpoints_required(boolean) : "Checkpoints Required" : 1 : "Is the player required to activate all checkpoints (in order) before progressing to the next stage? Otherwise, checkpoint zones may be skipped for this stage."
-	limit_ground_speed(boolean) : "Limit ground speed" : 0 : "Limit ground speed to walking speed (prevents bunny hopping)."
+	checkpoints_required(boolean) : "Checkpoints Required" : 0 : "Is the player required to activate all checkpoints before progressing to the next stage? Otherwise, checkpoint zones may be skipped for this stage."
+	checkpoints_ordered(boolean) : "Checkpoints Ordered" : 1 : "Are the checkpoints placed in a particular order?"
+	limit_ground_speed(boolean) : "Limit ground speed" : 1 : "Limit ground speed to walking speed (prevents bunny hopping)."
 	safe_height(float) : "Safe Height" : -1 : "Height that the player must be under to start a run of this stage track. Safe height is not a factor in activating the stage when running the full main track. -1 = full zone, 0 = base of zone, > 0 = custom height."
 	restart_destination(target_destination) : "Restart Destination" : : "The entity specifying the point to which the player should be teleported when restarting a stage. The player will be placed directly on the ground below this point if possible."
 	]

--- a/fgd/brush/trigger/zone_timer_stage_end.fgd
+++ b/fgd/brush/trigger/zone_timer_stage_end.fgd
@@ -1,6 +1,6 @@
 @SolidClass appliesto(MOMENTUM)
 = zone_timer_stage_end : "Zone that finishes the timer for a stage track. If not used for a stage, the start of the following stage (or map end) will automatically become the stage end."
 	[
-	filter_name(string) : "Filter Name" : : "filter_activator entity to use for this zone."
+	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
 	stage_number(integer) : "Stage Number" : 2 : "The stage number of this zone. NOTE: 1 is reserved for start! 2+ are free for your stage zones, so start at 2!"
 	]

--- a/fgd/brush/trigger/zone_timer_stage_end.fgd
+++ b/fgd/brush/trigger/zone_timer_stage_end.fgd
@@ -1,6 +1,0 @@
-@SolidClass appliesto(MOMENTUM)
-= zone_timer_stage_end : "Zone that finishes the timer for a stage track. If not used for a stage, the start of the following stage (or map end) will automatically become the stage end."
-	[
-	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
-	stage_number(integer) : "Stage Number" : 2 : "The stage number of this zone. NOTE: 1 is reserved for start! 2+ are free for your stage zones, so start at 2!"
-	]

--- a/fgd/brush/trigger/zone_timer_start.fgd
+++ b/fgd/brush/trigger/zone_timer_start.fgd
@@ -4,9 +4,14 @@
 	stage_name(string) : "Stage/Bonus Name" : : "A custom name for Stage 1 if this is a main track start, or a custom name for this track if it is a bonus start (optional)."
 	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
 	track_number(integer) : "Track Number" : 0 : "Track number that this entity belongs to. 0 = main map, 1+ = bonus (of that number)."
-	segments_ordered(boolean) : "Stages Ordered" : 1 : "Do the stages need to be completed in order? If not, every zone must also have an associated zone_timer_stage_end."
+	stage_end_zones[engine](integer) : "Stage End Zones" : 1
+	stage_end_zones(choices) : "Stage End Zones" : 1 : "If the map has stages, which zones should be used as stage end zones?" = 
+		[
+		0 : "Last Checkpoint"
+		1 : "Next Stage"
+		]
 	checkpoints_required(boolean) : "Checkpoints Required" : 0 : "Is the player required to activate all checkpoints before progressing? Otherwise, checkpoint zones may be skipped. If there are multiple stages, this only applies to Stage 1."
-	checkpoints_ordered(boolean) : "Checkpoints Ordered" : 1 : "Are the checkpoints placed in a particular order? If there are multiple stages, this only applies to Stage 1."
+	checkpoints_ordered(boolean) : "Checkpoints Ordered" : 1 : "Do the checkpoints in this segment have a logical order, even if the player is not required to activate them all? If there are multiple stages, this only applies to Stage 1."
 	safe_height(float) : "Safe Height" : -1 : "Height that the player must be under to start a run of this stage track. Safe height is not a factor in activating the stage when running the full main track. -1 = full zone, 0 = base of zone, > 0 = custom height."
 	max_velocity(float) : "Max Velocity" : 0 : "Maximum speed that the player can move at. 0 = unlimited, > 0 = custom limit."
 	restart_destination(target_destination) : "Restart Destination" : : "The entity specifying the point to which the player should be teleported when restarting a run."

--- a/fgd/brush/trigger/zone_timer_start.fgd
+++ b/fgd/brush/trigger/zone_timer_start.fgd
@@ -2,10 +2,11 @@
 = zone_timer_start : "Zone that starts the timer for a main map track or bonus track." 
 	[
 	stage_name(string) : "Stage/Bonus Name" : : "A custom name for Stage 1 if this is a main track start, or a custom name for this track if it is a bonus start (optional)."
-	filter_name(string) : "Filter Name" : : "filter_activator entity to use for this zone."
+	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
 	track_number(integer) : "Track Number" : 0 : "Track number that this entity belongs to. 0 = main map, 1+ = bonus (of that number)."
 	segments_ordered(boolean) : "Stages Ordered" : 1 : "Do the stages need to be completed in order? If not, every zone must also have an associated zone_timer_stage_end."
-	checkpoints_required(boolean) : "Checkpoints Required" : 1 : "Is the player required to activate all checkpoints (in order) before progressing? Otherwise, checkpoint zones may be skipped. If there are multiple stages, this only applies to Stage 1."
+	checkpoints_required(boolean) : "Checkpoints Required" : 0 : "Is the player required to activate all checkpoints before progressing? Otherwise, checkpoint zones may be skipped. If there are multiple stages, this only applies to Stage 1."
+	checkpoints_ordered(boolean) : "Checkpoints Ordered" : 1 : "Are the checkpoints placed in a particular order? If there are multiple stages, this only applies to Stage 1."
 	safe_height(float) : "Safe Height" : -1 : "Height that the player must be under to start a run of this stage track. Safe height is not a factor in activating the stage when running the full main track. -1 = full zone, 0 = base of zone, > 0 = custom height."
 	max_velocity(float) : "Max Velocity" : 0 : "Maximum speed that the player can move at. 0 = unlimited, > 0 = custom limit."
 	restart_destination(target_destination) : "Restart Destination" : : "The entity specifying the point to which the player should be teleported when restarting a run."

--- a/fgd/visgroups.cfg
+++ b/fgd/visgroups.cfg
@@ -205,7 +205,6 @@
 				* `zone_timer_start`
 				* `zone_timer_cancel`
 				* `zone_timer_end`
-				* `zone_timer_stage_end`
 			* `trigger_autosave`
 			* `trigger_bounce_stickybombs`
 			* `trigger_brush`


### PR DESCRIPTION
- Added checkpoints ordered field to zone_timer_start/stage
- Limit ground speed enabled by default
- Filter names now use filterclass dropdown
- Remove "Stages Ordered" property from zone_timer_start
- Remove zone_timer_stage_end
- Add "Stage End Zones" property with enum values: "Next Stage", "Last Checkpoint"