### PR TITLE
Updated func_instance.fgd

### DIFF
--- a/fgd/point/func/func_instance.fgd
+++ b/fgd/point/func/func_instance.fgd
@@ -8,7 +8,7 @@
 	[
 	targetname(target_source) : "Fix Up Name" : : "The name that all entities will be fixed up with based upon the fix up style."
 	file(instance_file) : "VMF Filename" : : "This indicates a map file relative to the map's file name. " +
-		"This is also looked up relative to sdk_content/maps/, if one exists in the parent directories."
+		"This is also looked up relative to <your mod>/maps/ or sdk_content/maps/, if one exists in the parent directories."
 
 	fixup_style[engine](integer) : "Entity Name Fix Up" : 0
 	fixup_style(choices) : "Entity Name Fix Up" : 0 : "Fixup style for instanced entity names.  Uses the 'Fix Up Name' field." =


### PR DESCRIPTION
Updated func_instance.fgd to clarify that instances are able to be loaded directly from the sourcemod, rather than just sdk_content