### PR TITLE
Change func_slide default to disallow jumping

### DIFF
--- a/fgd/brush/func/func_slide.fgd
+++ b/fgd/brush/func/func_slide.fgd
@@ -4,6 +4,6 @@
 	[
 	linedivider_slide(string) readonly : "----------------------------------------------------------------------------------------------------------"
 	stayonslide(boolean) : "Keep player on slide surface" : 0 : "Keep the player attached to the slide surface (for example, when sliding down ground of increasing steepness)."
-	allowjump(boolean) : "Allow jumping" : 1 : "Allow the player to jump while sliding. The player is still required to be on a surface that is not too steep to stand on in order to jump."
+	allowjump(boolean) : "Allow jumping" : 0 : "Allow the player to jump while sliding. The player is still required to be on a surface that is not too steep to stand on in order to jump."
 	disablegravity(boolean) : "Disable gravity" : 0 : "Disable gravity while sliding."
 	]


### PR DESCRIPTION
This gives func_slide more mechanical identity, otherwise the player can bhop on it like any other platform.