### PR TITLE
Add all tracks option to zone_timer_cancel

### DIFF
--- a/fgd/brush/trigger/zone_timer_cancel.fgd
+++ b/fgd/brush/trigger/zone_timer_cancel.fgd
@@ -2,6 +2,6 @@
 = zone_timer_cancel : "Zone that cancels the timer."
 	[
 	filter_name(filterclass) : "Filter Name" : : "filter_activator entity to use for this zone."
-	track_number(integer) : "Track Number" : 0 : "Track number that this entity belongs to. 0 = main map, 1+ = bonus (of that number)."
+	track_number(integer) : "Track Number" : 0 : "Track number that this entity belongs to. -1 = all tracks, 0 = main map, 1+ = bonus (of that number)."
 	stage_number(integer) : "Stage Number" : 1 : "The stage this cancel zone is part of. If this track has no stages, leave this as Stage 1."
 	]


### PR DESCRIPTION
Create a global cancel zone when setting the trackNum = -1 on `zone_timer_cancel`.