### PR TITLE
Remove variable "Time of day" from point entity worldspawn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ src/
 
 # Caches
 __pycache__
+/.vs/

--- a/fgd/worldspawn.fgd
+++ b/fgd/worldspawn.fgd
@@ -19,17 +19,6 @@
 		1: "Yes, clear previous levels"
 		]
 
-	timeofday[engine](integer) : "Time of day" : 0
-	timeofday(choices) : "Time of day" : 0 =
-		[
-		0: "Midnight"
-		1: "Dawn"
-		2: "Morning"
-		3: "Afternoon"
-		4: "Dusk"
-		5: "Evening"
-		]
-
 	maxoccludeearea(float) : "Max occludee area" : 0 : "[Used on PC] Prevents occlusion testing for entities that take up more than X% of the screen."
 	minoccluderarea(float) : "Min occluder area" : 0 : "[Used on PC] Prevents occluders from being used if they take up less than X% of the screen."
 	maxpropscreenwidth(float) : "Start Fade Pixels" : -1 : "Number of pixels wide at which all props in the level start to fade (<0 = use fademaxdist). " +


### PR DESCRIPTION
This has no point in existing on our engine branch FGD because it quite literally doesn't do anything outside of left4dead2.