### PR TITLE
Fix missing Initally Dark flag on light entities

### DIFF
--- a/fgd/bases/BaseClusteredLight.fgd
+++ b/fgd/bases/BaseClusteredLight.fgd
@@ -2,6 +2,7 @@
 	[
 	spawnflags(flags)  =
 		[
+		1: "Initially dark" : 0
 		2: "Shadowed" : 0
 		]
 	_lightmode(choices) : "Light mode" : 0 : "The level of dynamic lighting to use for this light. 'Static' lights have no dynamic or specular lighting, and produce direct and bounced static lightmaps. 'Specular' lights have specular lighting, and produce direct and bounced static lightmaps. 'Static Bounce' lights have dynamic direct and specular lighting, and produce only bounced static lightmaps. 'Fully Dynamic' lights have dynamic direct and specular lighting, and produce no static lightmaps." = 


### PR DESCRIPTION
It turns out this flag is fully functional on light_rt* too, but it's missing since the clustered update on all light entities.
This fixes the issue by adding it back.

Closes [Issue 1426](https://github.com/StrataSource/Engine/issues/1426)