### PR TITLE
Shadow size changes

### DIFF
--- a/fgd/bases/BaseClusteredLight.fgd
+++ b/fgd/bases/BaseClusteredLight.fgd
@@ -36,8 +36,7 @@
 		]
 
 	linedivider_clus2[!engine](string) readonly : "----------------------------------------------------------------------------------------------------------" : : "Oops, you must've misclicked."
-		
-	_initialshadowsize(integer) : "Initial Shadow Size" : 3 : "The initial static shadow resolution exponent. Only relevant for static shadow allocation. Adding 1 to this value doubles both dimensions of the shadowmap."
+
 	nearz(float) : "Near Z" : 4.0 : "Near Z for this light. Determines where shadows start to be cast. Inside the nearz radius, the light is still visible, but anything inside it won't cast shadows"
 
 	input SetShadowSize(integer) : "Set the size exponent of this light's shadowmap(s)."

--- a/fgd/point/light/light_rt.fgd
+++ b/fgd/point/light/light_rt.fgd
@@ -3,4 +3,13 @@
 	sphere(nearz)
 = light_rt: "An invisible omnidirectional realtime light-source."
 	[
+	_initialshadowsize(choices) : "Initial Shadow Size" : 3 : "The initial shadow resolution exponent for shadowed lights. Each increment of one doubles both dimensions of the shadowmap, making shadows appear sharper as a result." =
+		[
+		1: "1"
+		2: "2"
+		3: "3"
+		4: "4"
+		5: "5"
+		6: "6"
+		]
 	]


### PR DESCRIPTION
This PR makes the shadow dropdown in BaseClusteredLight that I added a long time ago work properly, along with clamping the omnidirectional light_rt shadow size kv to 6. Setting light_rt to size 7 causes the atlas to overflow, so the kv being limited to 6 helps prevents that from happening. Resolves StrataSource/Engine#1867